### PR TITLE
Add comment re: data availability

### DIFF
--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -5,6 +5,10 @@ from pangeo_forge_recipes.recipes import XarrayZarrRecipe
 
 dates = pd.date_range('2009-07-01', '2010-06-30', freq='D')
 
+# As documented in https://github.com/pangeo-forge/eNATL60-feedstock/issues/2, this server is not always
+# available to service high-bandwidth requests. Concurrency limits in Pangeo Forge, if added as a feature
+# in the future, may help. In the interim, re-running this recipe may require checking with the data
+# provider regarding the best time to request data from this server.
 url_base = (
     'https://ige-meom-opendap.univ-grenoble-alpes.fr'
     '/thredds/fileServer/meomopendap/extract/eNATL60/eNATL60-BLBT02/1d'


### PR DESCRIPTION
Memorializes the issues we've discussed in https://github.com/pangeo-forge/eNATL60-feedstock/issues/2 as a comment in the recipe.

Merging this PR also serves as a way to re-run the recipe (which failed initially due to data availability issues).